### PR TITLE
Firewall default policy

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,49 +36,50 @@ Also you can choose to run kube-router as agent running on each cluster node. Al
 
 ```
 Usage of kube-router:
-      --advertise-cluster-ip             Add Cluster IP of the service to the RIB so that it gets advertises to the BGP peers.
-      --advertise-external-ip            Add External IP of service to the RIB so that it gets advertised to the BGP peers.
-      --advertise-loadbalancer-ip        Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
-      --advertise-pod-cidr               Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
-      --bgp-graceful-restart             Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
-      --bgp-port uint16                  The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
-      --cache-sync-timeout duration      The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
-      --cleanup-config                   Cleanup iptables rules, ipvs, ipset configuration and exit.
-      --cluster-asn uint                 ASN number under which cluster nodes will run iBGP.
-      --cluster-cidr string              CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.
-      --disable-source-dest-check        Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
-      --enable-cni                       Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
-      --enable-ibgp                      Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
-      --enable-overlay                   When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
-      --enable-pod-egress                SNAT traffic from Pods to destinations outside the cluster. (default true)
-      --enable-pprof                     Enables pprof for debugging performance and memory leak issues.
-      --hairpin-mode                     Add iptables rules for every Service Endpoint to support hairpin traffic.
-      --health-port uint16               Health check port, 0 = Disabled (default 20244)
-  -h, --help                             Print usage information.
-      --hostname-override string         Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
-      --network-policy-handler string    Determines which implementation should be used as network policy handler, either of: "iptables", "nftables". (default "iptables")
-      --iptables-sync-period duration    The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 5m0s)
-      --ipvs-sync-period duration        The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
-      --kubeconfig string                Path to kubeconfig file with authorization information (the master location is set by the master flag).
-      --masquerade-all                   SNAT all traffic to cluster IP/node port.
-      --master string                    The address of the Kubernetes API server (overrides any value in kubeconfig).
-      --metrics-path string              Prometheus metrics path (default "/metrics")
-      --metrics-port uint16              Prometheus metrics port, (Default 0, Disabled)
-      --nodeport-bindon-all-ip           For service of NodePort type create IPVS service that listens on all IP's of the node.
-      --nodes-full-mesh                  Each node in the cluster will setup BGP peering with rest of the nodes. (default true)
-      --override-nexthop                 Override the next-hop in bgp routes sent to peers with the local ip.
-      --peer-router-asns uints           ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr. (default [])
-      --peer-router-ips ipSlice          The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's. (default [])
-      --peer-router-multihop-ttl uint8   Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
-      --peer-router-passwords strings    Password for authenticating against the BGP peer defined with "--peer-router-ips".
-      --peer-router-ports uints          The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
-      --router-id string                 BGP router-id. Must be specified in a ipv6 only cluster.
-      --routes-sync-period duration      The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
-      --run-firewall                     Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
-      --run-router                       Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
-      --run-service-proxy                Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
-  -v, --v string                         log level for V logs (default "0")
-  -V, --version                          Print version information.
+      --advertise-cluster-ip                   Add Cluster IP of the service to the RIB so that it gets advertises to the BGP peers.
+      --advertise-external-ip                  Add External IP of service to the RIB so that it gets advertised to the BGP peers.
+      --advertise-loadbalancer-ip              Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
+      --advertise-pod-cidr                     Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
+      --bgp-graceful-restart                   Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
+      --bgp-port uint16                        The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
+      --cache-sync-timeout duration            The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
+      --cleanup-config                         Cleanup iptables rules, ipvs, ipset configuration and exit.
+      --cluster-asn uint                       ASN number under which cluster nodes will run iBGP.
+      --cluster-cidr string                    CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.
+      --disable-source-dest-check              Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
+      --enable-cni                             Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
+      --enable-ibgp                            Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
+      --enable-overlay                         When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
+      --enable-pod-egress                      SNAT traffic from Pods to destinations outside the cluster. (default true)
+      --enable-pprof                           Enables pprof for debugging performance and memory leak issues.
+      --hairpin-mode                           Add iptables rules for every Service Endpoint to support hairpin traffic.
+      --health-port uint16                     Health check port, 0 = Disabled (default 20244)
+  -h, --help                                   Print usage information.
+      --hostname-override string               Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
+      --iptables-sync-period duration          The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 5m0s)
+      --ipvs-sync-period duration              The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
+      --kubeconfig string                      Path to kubeconfig file with authorization information (the master location is set by the master flag).
+      --masquerade-all                         SNAT all traffic to cluster IP/node port.
+      --master string                          The address of the Kubernetes API server (overrides any value in kubeconfig).
+      --metrics-path string                    Prometheus metrics path (default "/metrics")
+      --metrics-port uint16                    Prometheus metrics port, (Default 0, Disabled)
+      --network-policy-default-action string   Decides the default action to apply when no network policies apply to a pod, either of: either of: "allow", "deny". (default "allow")
+      --network-policy-handler string          Determines which implementation should be used as network policy handler, either of: "iptables", "nftables". (default "iptables")
+      --nodeport-bindon-all-ip                 For service of NodePort type create IPVS service that listens on all IP's of the node.
+      --nodes-full-mesh                        Each node in the cluster will setup BGP peering with rest of the nodes. (default true)
+      --override-nexthop                       Override the next-hop in bgp routes sent to peers with the local ip.
+      --peer-router-asns uints                 ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr. (default [])
+      --peer-router-ips ipSlice                The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's. (default [])
+      --peer-router-multihop-ttl uint8         Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
+      --peer-router-passwords strings          Password for authenticating against the BGP peer defined with "--peer-router-ips".
+      --peer-router-ports uints                The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
+      --router-id string                       BGP router-id. Must be specified in a ipv6 only cluster.
+      --routes-sync-period duration            The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
+      --run-firewall                           Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
+      --run-router                             Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
+      --run-service-proxy                      Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
+  -v, --v string                               log level for V logs (default "0")
+  -V, --version                                Print version information.
 ```
 
 ## requirements

--- a/pkg/controllers/netpol/iptables.go
+++ b/pkg/controllers/netpol/iptables.go
@@ -27,7 +27,7 @@ type IPTables struct {
 	ipSetHandler *utils.IPSet
 }
 
-func NewIPTablesHandler() (*IPTables, error) {
+func NewIPTablesHandler(podCIDR string, defaultDeny bool) (*IPTables, error) {
 	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -727,11 +727,17 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	npc.npLister = npInformer.GetIndexer()
 	npc.NetworkPolicyEventHandler = npc.newNetworkPolicyEventHandler()
 
-	iptables, err := NewIPTablesHandler()
+	podCidr, err := utils.GetPodCidrFromNodeSpec(clientset, config.HostnameOverride)
 	if err != nil {
 		return nil, err
 	}
-	nftables, err := NewNFTablesHandler()
+	defaultDeny := config.NetworkPolicyDefault == "deny"
+
+	iptables, err := NewIPTablesHandler(podCidr, defaultDeny)
+	if err != nil {
+		return nil, err
+	}
+	nftables, err := NewNFTablesHandler(podCidr, defaultDeny)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/netpol/nftables.go
+++ b/pkg/controllers/netpol/nftables.go
@@ -28,52 +28,52 @@ const (
 			{{range .EgressPods}}
 				ip saddr {{.IP}} jump {{.Namespace}}-{{.Name}}-egress-fw
 			{{end}}
-			{{if defaultDeny}}ip saddr { {{podCIDR}} } drop{{end}}
+			{{if defaultDeny}}ip saddr { {{podCIDR}} } {{template "drop"}}{{end}}
 		}
 
 		chain ingress-forward {
 			type filter hook forward priority 0; policy accept
 			{{template "accept" .}}
-			meta mark 32760 reject
+			meta mark 32760 {{template "reject"}}
 
 			{{range .IngressPods}}
 				ip daddr {{.IP}} jump {{.Namespace}}-{{.Name}}-ingress-fw
 			{{end}}
-			{{if defaultDeny}}ip daddr { {{podCIDR}} } drop{{end}}
+			{{if defaultDeny}}ip daddr { {{podCIDR}} } {{template "drop"}}{{end}}
 		}
 
 		chain ingress-output {
 			type filter hook output priority 0; policy accept
 			{{template "accept" .}}
-			meta mark 32760 reject
+			meta mark 32760 {{template "reject"}}
 
 			{{range .IngressPods}}
 				ip daddr {{.IP}} jump {{.Namespace}}-{{.Name}}-ingress-fw
 			{{end}}
-			{{if defaultDeny}}ip daddr { {{podCIDR}} } drop{{end}}
+			{{if defaultDeny}}ip daddr { {{podCIDR}} } {{template "drop"}}{{end}}
 		}
 
 		{{$policies := .Policies}}
 		{{range .IngressPods}}
 		chain {{.Namespace}}-{{.Name}}-ingress-fw {
 			ct state established,related accept
-			ct state invalid drop
+			ct state invalid {{template "drop"}}
 			{{with $pod := .}}
 			{{range $policies}}
 				{{if .Matches $pod}}jump {{.Namespace}}-{{.Name}}-netpol-ingress{{end}}{{end}}
 			{{end}}
-			reject
+			{{template "reject"}}
 		}
 		{{end}}
 		{{range .EgressPods}}
 		chain {{.Namespace}}-{{.Name}}-egress-fw {
 			ct state established,related accept
-			ct state invalid drop
+			ct state invalid {{template "drop"}}
 			{{with $pod := .}}
 			{{range $policies}}
 				{{if .Matches $pod}}jump {{.Namespace}}-{{.Name}}-netpol-egress{{end}}{{end}}
 			{{end}}
-			mark set 32760
+			{{template "markforreject"}}
 		}
 		{{end}}
 
@@ -120,6 +120,10 @@ const (
 		ip protocol icmp accept
 		{{if .LocalIp4}}ip saddr { {{range .LocalIp4}}{{.}},{{end}} } accept{{end}}
 	{{end}}
+	{{define "markforreject"}}nftrace set 1 mark set 32760{{end}}
+	{{define "reject"}}nftrace set 1 reject{{end}}
+	{{define "drop"}}nftrace set 1 drop{{end}}
+
 `
 )
 

--- a/pkg/controllers/netpol/nftables_test.go
+++ b/pkg/controllers/netpol/nftables_test.go
@@ -30,7 +30,7 @@ func TestNFTablesSimpleIngress(t *testing.T) {
 	iPods[pod1.IP] = *pod1
 	ePods[pod2.IP] = *pod2
 
-	nft, err := NewNFTablesHandler()
+	nft, err := NewNFTablesHandler("192.168.7.0/23", false)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -33,6 +33,7 @@ type KubeRouterConfig struct {
 	HelpRequested           bool
 	HostnameOverride        string
 	NetworkPolicyHandler	string
+	NetworkPolicyDefault	string
 	IPTablesSyncPeriod      time.Duration
 	IpvsSyncPeriod          time.Duration
 	Kubeconfig              string
@@ -95,6 +96,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"SNAT traffic from Pods to destinations outside the cluster.")
 	fs.StringVar(&s.NetworkPolicyHandler, "network-policy-handler", "iptables",
 		"Determines which implementation should be used as network policy handler, either of: \"iptables\", \"nftables\".")
+	fs.StringVar(&s.NetworkPolicyDefault, "network-policy-default-action", "allow",
+		"Decides the default action to apply when no network policies apply to a pod, either of: \"allow\", \"deny\".")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,
 		"The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0.")
 	fs.DurationVar(&s.IpvsSyncPeriod, "ipvs-sync-period", s.IpvsSyncPeriod,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -32,8 +32,8 @@ type KubeRouterConfig struct {
 	HealthPort              uint16
 	HelpRequested           bool
 	HostnameOverride        string
-	NetworkPolicyHandler	string
-	NetworkPolicyDefault	string
+	NetworkPolicyHandler    string
+	NetworkPolicyDefault    string
 	IPTablesSyncPeriod      time.Duration
 	IpvsSyncPeriod          time.Duration
 	Kubeconfig              string


### PR DESCRIPTION
Introduces a new flag to kube-router, i.e. `--network-policy-default-action`, which can either be `allow` or `deny`, allow being default. If set to "deny", kube-router will drop packets destined to pods, even if there's no network policies matching it. This eliminates the need for adding "deny-all" network policies to all namespaces if you want deny to be the default thing to happen.

If a netpol (on the other hand) _do_ match the pod, you will still, as usual, get an ICMP reject. The reason for DROP in the former case, is that during pod startup, you might need to wait a few milliseconds before netpols apply, in which case DROP is better, because it allows for TCP-retry until the firewall is properly configured.

**Hint to reviewer:** Review commits separately, since the `go fmt` commit is rather noisy.