### PR TITLE
netpol/nftables: make sure no single ipset have overlapping ip nets

### DIFF
--- a/pkg/controllers/netpol/nftables.go
+++ b/pkg/controllers/netpol/nftables.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"encoding/binary"
 )
 
 const (
@@ -356,14 +357,24 @@ func genIPSetFromEgressRule(rule EgressRule) string {
 }
 
 func getOrCreateSet(unfiltered []string) string {
-	ips := make([]string, 0)
+	nets := make([]string, 0)
 	for _, ip := range unfiltered {
 		if len(ip) > 1 {
-			ips = append(ips, ip)
+			if addr := net.ParseIP(ip); addr != nil { // if this is a plain address (non-cidr notation, add /32)
+				ip = ip + "/32"
+			}
+			nets = append(nets, ip)
 		}
 	}
-	sort.Strings(ips)
-	ipStr := strings.Join(ips, ",")
+	merged, err := MergeCIDRs(nets)
+	if err != nil {
+		// the thing is: "getOrCreateSet" is not really allowed to fail, so if merge fails, just log it and use the unmerged list
+		glog.Errorf("merging of cidrs failed for set: %v", nets, err)
+	} else {
+		nets = merged
+	}
+	sort.Strings(nets)
+	ipStr := strings.Join(nets, ",")
 	digest := sha256.Sum256([]byte(ipStr))
 	setName := fmt.Sprintf("set_%x", digest)
 	if _, ok := sets[setName]; !ok {
@@ -390,4 +401,238 @@ func genIpSet(positive string, negative string, matches string) string {
 	}
 
 	return builder.String()
+}
+
+/*
+	The following code is a hard vendoring of go-cidrman, because dep management
+	in this fork is difficult.
+
+	Attribution: https://github.com/EvilSuperstars/go-cidrman
+*/
+
+type ipNets []*net.IPNet
+
+func (nets ipNets) toCIDRs() []string {
+	var cidrs []string
+	for _, net := range nets {
+		cidrs = append(cidrs, net.String())
+	}
+
+	return cidrs
+}
+
+// MergeIPNets accepts a list of IP networks and merges them into the smallest possible list of IPNets.
+// It merges adjacent subnets where possible, those contained within others and removes any duplicates.
+func MergeIPNets(nets []*net.IPNet) ([]*net.IPNet, error) {
+	if nets == nil {
+		return nil, nil
+	}
+	if len(nets) == 0 {
+		return make([]*net.IPNet, 0), nil
+	}
+
+	// Split into IPv4 and IPv6 lists.
+	// Merge the list separately and then combine.
+	var block4s cidrBlock4s
+	for _, net := range nets {
+		ip4 := net.IP.To4()
+		if ip4 != nil {
+			block4s = append(block4s, newBlock4(ip4, net.Mask))
+		} else {
+			return nil, errors.New("Not implemented")
+		}
+	}
+
+	merged, err := merge4(block4s)
+	if err != nil {
+		return nil, err
+	}
+
+	return merged, nil
+}
+
+// MergeCIDRs accepts a list of CIDR blocks and merges them into the smallest possible list of CIDRs.
+func MergeCIDRs(cidrs []string) ([]string, error) {
+	if cidrs == nil {
+		return nil, nil
+	}
+	if len(cidrs) == 0 {
+		return make([]string, 0), nil
+	}
+
+	var networks []*net.IPNet
+	for _, cidr := range cidrs {
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, err
+		}
+		networks = append(networks, network)
+	}
+	mergedNets, err := MergeIPNets(networks)
+	if err != nil {
+		return nil, err
+	}
+
+	return ipNets(mergedNets).toCIDRs(), nil
+}
+
+// ipv4ToUInt32 converts an IPv4 address to an unsigned 32-bit integer.
+func ipv4ToUInt32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip)
+}
+
+// uint32ToIPV4 converts an unsigned 32-bit integer to an IPv4 address.
+func uint32ToIPV4(addr uint32) net.IP {
+	ip := make([]byte, net.IPv4len)
+	binary.BigEndian.PutUint32(ip, addr)
+	return ip
+}
+
+// The following functions are inspired by http://www.cs.colostate.edu/~somlo/iprange.c.
+
+// setBit sets the specified bit in an address to 0 or 1.
+func setBit(addr uint32, bit uint, val uint) uint32 {
+	if bit < 0 {
+		panic("negative bit index")
+	}
+
+	if val == 0 {
+		return addr & ^(1 << (32 - bit))
+	} else if val == 1 {
+		return addr | (1 << (32 - bit))
+	} else {
+		panic("set bit is not 0 or 1")
+	}
+}
+
+// netmask returns the netmask for the specified prefix.
+func netmask(prefix uint) uint32 {
+	if prefix == 0 {
+		return 0
+	}
+	return ^uint32((1 << (32 - prefix)) - 1)
+}
+
+// broadcast4 returns the broadcast address for the given address and prefix.
+func broadcast4(addr uint32, prefix uint) uint32 {
+	return addr | ^netmask(prefix)
+}
+
+// network4 returns the network address for the given address and prefix.
+func network4(addr uint32, prefix uint) uint32 {
+	return addr & netmask(prefix)
+}
+
+// splitRange4 recursively computes the CIDR blocks to cover the range lo to hi.
+func splitRange4(addr uint32, prefix uint, lo, hi uint32, cidrs *[]*net.IPNet) error {
+	if prefix > 32 {
+		return fmt.Errorf("Invalid mask size: %d", prefix)
+	}
+
+	bc := broadcast4(addr, prefix)
+	if (lo < addr) || (hi > bc) {
+		return fmt.Errorf("%d, %d out of range for network %d/%d, broadcast %d", lo, hi, addr, prefix, bc)
+	}
+
+	if (lo == addr) && (hi == bc) {
+		cidr := net.IPNet{IP: uint32ToIPV4(addr), Mask: net.CIDRMask(int(prefix), 8*net.IPv4len)}
+		*cidrs = append(*cidrs, &cidr)
+		return nil
+	}
+
+	prefix++
+	lowerHalf := addr
+	upperHalf := setBit(addr, prefix, 1)
+	if hi < upperHalf {
+		return splitRange4(lowerHalf, prefix, lo, hi, cidrs)
+	} else if lo >= upperHalf {
+		return splitRange4(upperHalf, prefix, lo, hi, cidrs)
+	} else {
+		err := splitRange4(lowerHalf, prefix, lo, broadcast4(lowerHalf, prefix), cidrs)
+		if err != nil {
+			return err
+		}
+		return splitRange4(upperHalf, prefix, upperHalf, hi, cidrs)
+	}
+}
+
+// IPv4 CIDR block.
+
+type cidrBlock4 struct {
+	first uint32
+	last  uint32
+}
+
+type cidrBlock4s []*cidrBlock4
+
+// newBlock4 returns a new IPv4 CIDR block.
+func newBlock4(ip net.IP, mask net.IPMask) *cidrBlock4 {
+	var block cidrBlock4
+
+	block.first = ipv4ToUInt32(ip)
+	prefix, _ := mask.Size()
+	block.last = broadcast4(block.first, uint(prefix))
+
+	return &block
+}
+
+// Sort interface.
+
+func (c cidrBlock4s) Len() int {
+	return len(c)
+}
+
+func (c cidrBlock4s) Less(i, j int) bool {
+	lhs := c[i]
+	rhs := c[j]
+
+	// By last IP in the range.
+	if lhs.last < rhs.last {
+		return true
+	} else if lhs.last > rhs.last {
+		return false
+	}
+
+	// Then by first IP in the range.
+	if lhs.first < rhs.first {
+		return true
+	} else if lhs.first > rhs.first {
+		return false
+	}
+
+	return false
+}
+
+func (c cidrBlock4s) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+
+// merge4 accepts a list of IPv4 networks and merges them into the smallest possible list of IPNets.
+// It merges adjacent subnets where possible, those contained within others and removes any duplicates.
+func merge4(blocks cidrBlock4s) ([]*net.IPNet, error) {
+	sort.Sort(blocks)
+
+	// Coalesce overlapping blocks.
+	for i := len(blocks) - 1; i > 0; i-- {
+		if blocks[i].first <= blocks[i-1].last+1 {
+			blocks[i-1].last = blocks[i].last
+			if blocks[i].first < blocks[i-1].first {
+				blocks[i-1].first = blocks[i].first
+			}
+			blocks[i] = nil
+		}
+	}
+
+	var merged []*net.IPNet
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+
+		if err := splitRange4(0, 0, block.first, block.last, &merged); err != nil {
+			return nil, err
+		}
+	}
+
+	return merged, nil
 }


### PR DESCRIPTION
**No merge yet, please** .. Let's try this in prod first. Keep on reading.

**The good news** is that this solves the problem at hand, i.e. if you make a netpol like so:

```
...
  ingress:
  - from:
    - ipBlock:
        cidr: 172.18.5.0/24
    - ipBlock:
        cidr: 172.18.0.0/16
```

with overlapping IP-blocks, the current version of kube-router fails sync of netpols, since nftables don't like overlapping nets in the same ipset.

This PR solves this by checking for overlaps while generating ipsets and selecting the widest network, discarding the narrowest if there are overlaps.

**The bad news** is that preliminary tests on staging suggests that sync of network policies now takes ~100-120ms instead of 50-60ms. I have no data to tell how much of the time gain is constant, linear or exponential, but assuming this is linearly applicable on prod, we might see a rise in "time-to-online" from 1-2 secs to 2-4 secs. :(

We don't know yet whether this ^ is the case, hence I suggest that we try this out in production and if time to online suddenly becomes bad, we might need to roll this back. An alternative to a change in kube-router could be an admission controller failing on overlapping `ipBlocks` in netpol. I don't think we can end up with overlapping nets in sets any other ways than with manually defined ip blocks? :thinking:

The danger with solving this in admission controllers is of course that cidr overlaps might sneak in after admission is processed.
