### PR TITLE
V0.2.5 nftables router sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _output
 _cache
 Dockerfile.amd64.run
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoPackage }:
+
+buildGoPackage rec {
+  pname = "kube-router";
+  version = "0.2.5";
+
+  goPackagePath = "github.com/cloudnativelabs/kube-router";
+
+  src = ./.;
+
+  ldflags = [
+    "-X ${goPackagePath}/pkg/cmd.version=${version}"
+    "-X ${goPackagePath}/pkg/cmd.buildDate=Nix"
+  ];
+
+  meta = with lib; {
+    homepage = "https://www.kube-router.io/";
+    description = "All-in-one router, firewall and service proxy for Kubernetes";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ colemickens johanot ];
+    platforms = platforms.linux;
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
-{ lib, buildGoPackage }:
+{ pkgs ? import <nixpkgs> {} }:
 
-buildGoPackage rec {
+pkgs.buildGoPackage rec {
   pname = "kube-router";
   version = "0.2.5";
 
@@ -13,7 +13,7 @@ buildGoPackage rec {
     "-X ${goPackagePath}/pkg/cmd.buildDate=Nix"
   ];
 
-  meta = with lib; {
+  meta = with pkgs.lib; {
     homepage = "https://www.kube-router.io/";
     description = "All-in-one router, firewall and service proxy for Kubernetes";
     license = licenses.asl20;

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,7 @@ Usage of kube-router:
       --health-port uint16                     Health check port, 0 = Disabled (default 20244)
   -h, --help                                   Print usage information.
       --hostname-override string               Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
+      --injected-routes-sync-period duration   The delay between route table synchronizations  (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 1m0s)
       --iptables-sync-period duration          The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 5m0s)
       --ipvs-sync-period duration              The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --kubeconfig string                      Path to kubeconfig file with authorization information (the master location is set by the master flag).
@@ -211,7 +212,7 @@ Please read below blog on how to user DSR in combination with `--advertise-exter
 https://cloudnativelabs.github.io/post/2017-11-01-kube-high-available-ingress/
 
 You can enable DSR(Direct Server Return) functionality per service. When enabled service endpoint
-will directly respond to the client by passing the service proxy. When DSR is enabled Kube-router 
+will directly respond to the client by passing the service proxy. When DSR is enabled Kube-router
 will uses LVS's tunneling mode to achieve this.
 
 To enable DSR you need to annotate service with `kube-router.io/service.dsr=tunnel` annotation. For e.g.
@@ -227,14 +228,14 @@ kubectl annotate service my-service "kube-router.io/service.dsr=tunnel"
 You will need to enable `hostIPC: true` and `hostPID: true` in kube-router daemonset manifest.
 Also host path `/var/run/docker.sock` must be made a volumemount to kube-router.
 
-Above changes are required for kube-router to enter pod namespeace and create ipip tunnel in the pod and to 
-assign the external IP to the VIP. 
+Above changes are required for kube-router to enter pod namespeace and create ipip tunnel in the pod and to
+assign the external IP to the VIP.
 
 For an e.g manifest please look at [manifest](../daemonset/kubeadm-kuberouter-all-features-dsr.yaml) with DSR requirements enabled.
 
 ## Load balancing Scheduling Algorithms
 
-Kube-router uses LVS for service proxy. LVS support rich set of [scheduling alogirthms](http://kb.linuxvirtualserver.org/wiki/IPVS#Job_Scheduling_Algorithms). You can annotate 
+Kube-router uses LVS for service proxy. LVS support rich set of [scheduling alogirthms](http://kb.linuxvirtualserver.org/wiki/IPVS#Job_Scheduling_Algorithms). You can annotate
 the service to choose one of the scheduling alogirthms. When a service is not annotated `round-robin` scheduler is selected by default
 
 ```

--- a/pkg/controllers/routing/route_sync.go
+++ b/pkg/controllers/routing/route_sync.go
@@ -1,0 +1,81 @@
+package routing
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog/v2"
+)
+
+type routeSyncer struct {
+	routeTableStateMap       map[string]*netlink.Route
+	injectedRoutesSyncPeriod time.Duration
+	mutex                    sync.Mutex
+	routeReplacer            func(route *netlink.Route) error
+}
+
+// addInjectedRoute adds a route to the route map that is regularly synced to the kernel's routing table
+func (rs *routeSyncer) addInjectedRoute(dst *net.IPNet, route *netlink.Route) {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+	klog.V(3).Infof("Adding route for destination: %s", dst)
+	rs.routeTableStateMap[dst.String()] = route
+}
+
+// delInjectedRoute delete a route from the route map that is regularly synced to the kernel's routing table
+func (rs *routeSyncer) delInjectedRoute(dst *net.IPNet) {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+	if _, ok := rs.routeTableStateMap[dst.String()]; ok {
+		klog.V(3).Infof("Removing route for destination: %s", dst)
+		delete(rs.routeTableStateMap, dst.String())
+	}
+}
+
+// syncLocalRouteTable iterates over the local route state map and syncs all routes to the kernel's routing table
+func (rs *routeSyncer) syncLocalRouteTable() {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+	klog.V(2).Infof("Running local route table synchronization")
+	for dst, route := range rs.routeTableStateMap {
+		klog.V(3).Infof("Syncing route: %s", dst)
+		err := rs.routeReplacer(route)
+		if err != nil {
+			klog.Errorf("Route could not be replaced due to : " + err.Error())
+		}
+	}
+}
+
+// run starts a goroutine that calls syncLocalRouteTable on interval injectedRoutesSyncPeriod
+func (rs *routeSyncer) run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	// Start route synchronization routine
+	wg.Add(1)
+	go func(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+		defer wg.Done()
+		t := time.NewTicker(rs.injectedRoutesSyncPeriod)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				rs.syncLocalRouteTable()
+			case <-stopCh:
+				klog.Infof("Shutting down local route synchronization")
+				return
+			}
+		}
+	}(stopCh, wg)
+}
+
+// newRouteSyncer creates a new routeSyncer that, when run, will sync routes kept in its local state table every
+// syncPeriod
+func newRouteSyncer(syncPeriod time.Duration) *routeSyncer {
+	rs := routeSyncer{}
+	rs.routeTableStateMap = make(map[string]*netlink.Route)
+	rs.injectedRoutesSyncPeriod = syncPeriod
+	rs.mutex = sync.Mutex{}
+	// We substitute the RouteReplace function here so that we can easily monkey patch it in our unit tests
+	rs.routeReplacer = netlink.RouteReplace
+	return &rs
+}

--- a/pkg/controllers/routing/route_sync.go
+++ b/pkg/controllers/routing/route_sync.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/vishvananda/netlink"
-	"k8s.io/klog/v2"
+	"github.com/golang/glog"
 )
 
 type routeSyncer struct {
@@ -20,7 +20,7 @@ type routeSyncer struct {
 func (rs *routeSyncer) addInjectedRoute(dst *net.IPNet, route *netlink.Route) {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
-	klog.V(3).Infof("Adding route for destination: %s", dst)
+	glog.Infof("Adding route for destination: %s", dst)
 	rs.routeTableStateMap[dst.String()] = route
 }
 
@@ -29,7 +29,7 @@ func (rs *routeSyncer) delInjectedRoute(dst *net.IPNet) {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
 	if _, ok := rs.routeTableStateMap[dst.String()]; ok {
-		klog.V(3).Infof("Removing route for destination: %s", dst)
+		glog.Infof("Removing route for destination: %s", dst)
 		delete(rs.routeTableStateMap, dst.String())
 	}
 }
@@ -38,12 +38,12 @@ func (rs *routeSyncer) delInjectedRoute(dst *net.IPNet) {
 func (rs *routeSyncer) syncLocalRouteTable() {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
-	klog.V(2).Infof("Running local route table synchronization")
+	glog.Infof("Running local route table synchronization")
 	for dst, route := range rs.routeTableStateMap {
-		klog.V(3).Infof("Syncing route: %s", dst)
+		glog.Infof("Syncing route: %s", dst)
 		err := rs.routeReplacer(route)
 		if err != nil {
-			klog.Errorf("Route could not be replaced due to : " + err.Error())
+			glog.Errorf("Route could not be replaced due to : " + err.Error())
 		}
 	}
 }
@@ -61,7 +61,7 @@ func (rs *routeSyncer) run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 			case <-t.C:
 				rs.syncLocalRouteTable()
 			case <-stopCh:
-				klog.Infof("Shutting down local route synchronization")
+				glog.Infof("Shutting down local route synchronization")
 				return
 			}
 		}

--- a/pkg/controllers/routing/route_sync_test.go
+++ b/pkg/controllers/routing/route_sync_test.go
@@ -1,0 +1,168 @@
+package routing
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+)
+
+var (
+	testRoutes = map[string]string{
+		"192.168.0.1": "192.168.0.0/24",
+		"10.255.0.1":  "10.255.0.0/16",
+	}
+	_, testAddRouteIPNet, _ = net.ParseCIDR("192.168.1.0/24")
+	testAddRouteRoute       = generateTestRoute("192.168.1.0/24", "192.168.1.1")
+)
+
+func generateTestRoute(dstCIDR string, dstGateway string) *netlink.Route {
+	ip, ipNet, _ := net.ParseCIDR(dstCIDR)
+	gwIP := net.ParseIP(dstGateway)
+	return &netlink.Route{
+		Dst: &net.IPNet{
+			IP:   ip,
+			Mask: ipNet.Mask,
+		},
+		Gw: gwIP,
+	}
+}
+
+func generateTestRouteMap(inputRouteMap map[string]string) map[string]*netlink.Route {
+	testRoutes := make(map[string]*netlink.Route)
+	for gw, dst := range inputRouteMap {
+		testRoutes[dst] = generateTestRoute(dst, gw)
+	}
+	return testRoutes
+}
+
+type mockNetlink struct {
+	currentRoute *netlink.Route
+	pause        time.Duration
+	wg           *sync.WaitGroup
+}
+
+func (mnl *mockNetlink) mockRouteReplace(route *netlink.Route) error {
+	mnl.currentRoute = route
+	if mnl.wg != nil {
+		mnl.wg.Done()
+		time.Sleep(mnl.pause)
+	}
+	return nil
+}
+
+func Test_syncLocalRouteTable(t *testing.T) {
+	prepSyncLocalTest := func() (*mockNetlink, *routeSyncer) {
+		// Create myNetlink so that it will wait 200 milliseconds on routeReplace and artificially hold its lock
+		myNetlink := mockNetlink{}
+		myNetlink.pause = time.Millisecond * 200
+
+		// Create a route replacer and seed it with some routes to iterate over
+		syncer := newRouteSyncer(15 * time.Second)
+		syncer.routeTableStateMap = generateTestRouteMap(testRoutes)
+
+		// Replace the netlink.RouteReplace function with our own mock function that includes a WaitGroup for syncing
+		// and an artificial pause and won't interact with the OS
+		syncer.routeReplacer = myNetlink.mockRouteReplace
+
+		return &myNetlink, syncer
+	}
+
+	waitForSyncLocalRouteToAcquireLock := func(myNetlink *mockNetlink, syncer *routeSyncer) {
+		// Launch syncLocalRouteTable in a separate goroutine so that we can try to inject a route into the map while it
+		// is syncing. Then wait on the wait group so that we know that syncLocalRouteTable has a hold on the lock when
+		// we try to use it in addInjectedRoute() below
+		myNetlink.wg = &sync.WaitGroup{}
+		myNetlink.wg.Add(1)
+		go syncer.syncLocalRouteTable()
+
+		// Now we know that the syncLocalRouteTable() is paused on our artificial wait we added above
+		myNetlink.wg.Wait()
+		// We no longer need the wait group, so we change it to a nil reference so that it won't come into play in the
+		// next iteration of the route map
+		myNetlink.wg = nil
+	}
+
+	t.Run("Ensure addInjectedRoute is goroutine safe", func(t *testing.T) {
+		myNetlink, syncer := prepSyncLocalTest()
+
+		waitForSyncLocalRouteToAcquireLock(myNetlink, syncer)
+
+		// By measuring how much time it takes to inject the route we can understand whether addInjectedRoute waited
+		// for the lock to be returned or not
+		start := time.Now()
+		syncer.addInjectedRoute(testAddRouteIPNet, testAddRouteRoute)
+		duration := time.Since(start)
+
+		// We give ourselves a bit of leeway here, and say that if we were forced to wait for at least 190 milliseconds
+		// then that is evidence that execution was stalled while trying to acquire a lock from syncLocalRouteTable()
+		assert.Greater(t, duration, time.Millisecond*190,
+			"Expected addInjectedRoute to take longer than 190 milliseconds to prove locking works")
+	})
+
+	t.Run("Ensure delInjectedRoute is goroutine safe", func(t *testing.T) {
+		myNetlink, syncer := prepSyncLocalTest()
+
+		waitForSyncLocalRouteToAcquireLock(myNetlink, syncer)
+
+		// By measuring how much time it takes to inject the route we can understand whether addInjectedRoute waited
+		// for the lock to be returned or not
+		start := time.Now()
+		syncer.delInjectedRoute(testAddRouteIPNet)
+		duration := time.Since(start)
+
+		// We give ourselves a bit of leeway here, and say that if we were forced to wait for at least 190 milliseconds
+		// then that is evidence that execution was stalled while trying to acquire a lock from syncLocalRouteTable()
+		assert.Greater(t, duration, time.Millisecond*190,
+			"Expected addInjectedRoute to take longer than 190 milliseconds to prove locking works")
+	})
+}
+
+func Test_routeSyncer_run(t *testing.T) {
+	// Taken from:https://stackoverflow.com/questions/32840687/timeout-for-waitgroup-wait
+	// waitTimeout waits for the waitgroup for the specified max timeout.
+	// Returns true if waiting timed out.
+	waitTimeout := func(wg *sync.WaitGroup, timeout time.Duration) bool {
+		c := make(chan struct{})
+		go func() {
+			defer close(c)
+			wg.Wait()
+		}()
+		select {
+		case <-c:
+			return false // completed normally
+		case <-time.After(timeout):
+			return true // timed out
+		}
+	}
+
+	t.Run("Ensure that run goroutine shuts down correctly on stop", func(t *testing.T) {
+		// Setup routeSyncer to run 10 times a second
+		syncer := newRouteSyncer(100 * time.Millisecond)
+		myNetLink := mockNetlink{}
+		syncer.routeReplacer = myNetLink.mockRouteReplace
+		syncer.routeTableStateMap = generateTestRouteMap(testRoutes)
+		stopCh := make(chan struct{})
+		wg := sync.WaitGroup{}
+
+		// For a sanity check that the currentRoute on the mock object is nil to start with as we'll rely on this later
+		assert.Nil(t, myNetLink.currentRoute, "currentRoute should be nil when the syncer hasn't run")
+
+		syncer.run(stopCh, &wg)
+
+		time.Sleep(110 * time.Millisecond)
+
+		assert.NotNil(t, myNetLink.currentRoute,
+			"the syncer should have run by now and populated currentRoute")
+
+		// Simulate a shutdown
+		close(stopCh)
+		// WaitGroup should close out before our timeout
+		timedOut := waitTimeout(&wg, 110*time.Millisecond)
+
+		assert.False(t, timedOut, "WaitGroup should have marked itself as done instead of timing out")
+	})
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -36,6 +36,7 @@ type KubeRouterConfig struct {
 	NetworkPolicyDefault    string
 	IPTablesSyncPeriod      time.Duration
 	NetpolRollupPeriod      time.Duration
+  InjectedRoutesSyncPeriod       time.Duration
 	IpvsSyncPeriod          time.Duration
 	Kubeconfig              string
 	MasqueradeAll           bool
@@ -67,6 +68,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		IPTablesSyncPeriod: 5 * time.Minute,
 		NetpolRollupPeriod: 1 * time.Second,
 		RoutesSyncPeriod:   5 * time.Minute,
+		InjectedRoutesSyncPeriod:       60 * time.Second,
 		EnableOverlay:      true,
 	}
 }
@@ -100,6 +102,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Determines which implementation should be used as network policy handler, either of: \"iptables\", \"nftables\".")
 	fs.StringVar(&s.NetworkPolicyDefault, "network-policy-default-action", "allow",
 		"Decides the default action to apply when no network policies apply to a pod, either of: \"allow\", \"deny\".")
+	fs.DurationVar(&s.InjectedRoutesSyncPeriod, "injected-routes-sync-period", s.InjectedRoutesSyncPeriod,
+	"The delay between route table synchronizations  (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,
 		"The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0.")
 	fs.DurationVar(&s.IpvsSyncPeriod, "ipvs-sync-period", s.IpvsSyncPeriod,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -11,65 +11,65 @@ import (
 const DEFAULT_BGP_PORT = 179
 
 type KubeRouterConfig struct {
-	AdvertiseClusterIp      bool
-	AdvertiseExternalIp     bool
-	AdvertiseNodePodCidr    bool
-	AdvertiseLoadBalancerIp bool
-	BGPGracefulRestart      bool
-	BGPPort                 uint16
-	CacheSyncTimeout        time.Duration
-	CleanupConfig           bool
-	ClusterAsn              uint
-	ClusterCIDR             string
-	DisableSrcDstCheck      bool
-	EnableCNI               bool
-	EnableiBGP              bool
-	EnableOverlay           bool
-	EnablePodEgress         bool
-	EnablePprof             bool
-	FullMeshMode            bool
-	GlobalHairpinMode       bool
-	HealthPort              uint16
-	HelpRequested           bool
-	HostnameOverride        string
-	NetworkPolicyHandler    string
-	NetworkPolicyDefault    string
-	IPTablesSyncPeriod      time.Duration
-	NetpolRollupPeriod      time.Duration
-  InjectedRoutesSyncPeriod       time.Duration
-	IpvsSyncPeriod          time.Duration
-	Kubeconfig              string
-	MasqueradeAll           bool
-	Master                  string
-	MetricsEnabled          bool
-	MetricsPath             string
-	MetricsPort             uint16
-	NodePortBindOnAllIp     bool
-	OverrideNextHop         bool
-	PeerASNs                []uint
-	PeerMultihopTtl         uint8
-	PeerPasswords           []string
-	PeerPorts               []uint
-	PeerRouters             []net.IP
-	RouterId                string
-	RoutesSyncPeriod        time.Duration
-	RunFirewall             bool
-	RunRouter               bool
-	RunServiceProxy         bool
-	Version                 bool
-	VLevel                  string
+	AdvertiseClusterIp       bool
+	AdvertiseExternalIp      bool
+	AdvertiseNodePodCidr     bool
+	AdvertiseLoadBalancerIp  bool
+	BGPGracefulRestart       bool
+	BGPPort                  uint16
+	CacheSyncTimeout         time.Duration
+	CleanupConfig            bool
+	ClusterAsn               uint
+	ClusterCIDR              string
+	DisableSrcDstCheck       bool
+	EnableCNI                bool
+	EnableiBGP               bool
+	EnableOverlay            bool
+	EnablePodEgress          bool
+	EnablePprof              bool
+	FullMeshMode             bool
+	GlobalHairpinMode        bool
+	HealthPort               uint16
+	HelpRequested            bool
+	HostnameOverride         string
+	NetworkPolicyHandler     string
+	NetworkPolicyDefault     string
+	IPTablesSyncPeriod       time.Duration
+	NetpolRollupPeriod       time.Duration
+	InjectedRoutesSyncPeriod time.Duration
+	IpvsSyncPeriod           time.Duration
+	Kubeconfig               string
+	MasqueradeAll            bool
+	Master                   string
+	MetricsEnabled           bool
+	MetricsPath              string
+	MetricsPort              uint16
+	NodePortBindOnAllIp      bool
+	OverrideNextHop          bool
+	PeerASNs                 []uint
+	PeerMultihopTtl          uint8
+	PeerPasswords            []string
+	PeerPorts                []uint
+	PeerRouters              []net.IP
+	RouterId                 string
+	RoutesSyncPeriod         time.Duration
+	RunFirewall              bool
+	RunRouter                bool
+	RunServiceProxy          bool
+	Version                  bool
+	VLevel                   string
 	// FullMeshPassword    string
 }
 
 func NewKubeRouterConfig() *KubeRouterConfig {
 	return &KubeRouterConfig{
-		CacheSyncTimeout:   1 * time.Minute,
-		IpvsSyncPeriod:     5 * time.Minute,
-		IPTablesSyncPeriod: 5 * time.Minute,
-		NetpolRollupPeriod: 1 * time.Second,
-		RoutesSyncPeriod:   5 * time.Minute,
-		InjectedRoutesSyncPeriod:       60 * time.Second,
-		EnableOverlay:      true,
+		CacheSyncTimeout:         1 * time.Minute,
+		IpvsSyncPeriod:           5 * time.Minute,
+		IPTablesSyncPeriod:       5 * time.Minute,
+		NetpolRollupPeriod:       1 * time.Second,
+		RoutesSyncPeriod:         5 * time.Minute,
+		InjectedRoutesSyncPeriod: 60 * time.Second,
+		EnableOverlay:            true,
 	}
 }
 
@@ -103,7 +103,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.NetworkPolicyDefault, "network-policy-default-action", "allow",
 		"Decides the default action to apply when no network policies apply to a pod, either of: \"allow\", \"deny\".")
 	fs.DurationVar(&s.InjectedRoutesSyncPeriod, "injected-routes-sync-period", s.InjectedRoutesSyncPeriod,
-	"The delay between route table synchronizations  (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
+		"The delay between route table synchronizations  (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,
 		"The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0.")
 	fs.DurationVar(&s.IpvsSyncPeriod, "ipvs-sync-period", s.IpvsSyncPeriod,


### PR DESCRIPTION
Add PR https://github.com/cloudnativelabs/kube-router/pull/1262/files 

Test  from a k8s node: 
```
[root@container-s01:~]# ip r
default via 172.20.34.1 dev ens160 proto static 
10.235.0.0/24 via 172.20.35.2 dev ens160 proto 17 
10.235.3.0/24 via 172.20.35.3 dev ens160 proto 17 
10.235.5.0/24 dev kube-bridge proto kernel scope link src 10.235.5.1 
10.235.6.0/24 via 172.20.35.4 dev ens160 proto 17 
10.235.7.0/24 via 172.20.35.5 dev ens160 proto 17 
172.20.34.0/23 dev ens160 proto kernel scope link src 172.20.35.1 
192.168.160.0/20 dev ens192 proto kernel scope link src 192.168.163.14 metric 1024 

[root@container-s01:~]# ip route del 10.235.7.0/24

[root@container-s01:~]# ip r
default via 172.20.34.1 dev ens160 proto static 
10.235.0.0/24 via 172.20.35.2 dev ens160 proto 17 
10.235.3.0/24 via 172.20.35.3 dev ens160 proto 17 
10.235.5.0/24 dev kube-bridge proto kernel scope link src 10.235.5.1 
10.235.6.0/24 via 172.20.35.4 dev ens160 proto 17 
172.20.34.0/23 dev ens160 proto kernel scope link src 172.20.35.1 
192.168.160.0/20 dev ens192 proto kernel scope link src 192.168.163.14 metric 1024 

[root@container-s01:~]# ip r
default via 172.20.34.1 dev ens160 proto static 
10.235.0.0/24 via 172.20.35.2 dev ens160 proto 17 
10.235.3.0/24 via 172.20.35.3 dev ens160 proto 17 
10.235.5.0/24 dev kube-bridge proto kernel scope link src 10.235.5.1 
10.235.6.0/24 via 172.20.35.4 dev ens160 proto 17 
10.235.7.0/24 via 172.20.35.5 dev ens160 proto 17 
172.20.34.0/23 dev ens160 proto kernel scope link src 172.20.35.1 
192.168.160.0/20 dev ens192 proto kernel scope link src 192.168.163.14 metric 1024 

```
Log from kube-router:

```
May 02 10:14:15 container-s01 kube-router-start[2351763]: I0502 10:14:15.733134 2351763 network_policy_controller.go:145] Performing periodic sync to reflect network policies
May 02 10:14:15 container-s01 kube-router-start[2351763]: I0502 10:14:15.733234 2351763 network_policy_controller.go:246] Starting sync of network policies
May 02 10:14:15 container-s01 kube-router-start[2351763]: I0502 10:14:15.840005 2351763 network_policy_controller.go:243] sync network policies took 106.754413ms
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.043969 2351763 network_routes_controller.go:264] Syncing ipsets
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.044091 2351763 route_sync.go:41] Running local route table synchronization
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.044162 2351763 route_sync.go:43] Syncing route: 10.235.3.0/24
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.044598 2351763 route_sync.go:43] Syncing route: 10.235.7.0/24
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.045432 2351763 route_sync.go:43] Syncing route: 10.235.0.0/24
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.045859 2351763 route_sync.go:43] Syncing route: 10.235.6.0/24
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.222879 2351763 network_routes_controller.go:283] Performing periodic sync of service VIP routes
May 02 10:14:16 container-s01 kube-router-start[2351763]: I0502 10:14:16.222930 2351763 network_routes_controller.go:287] Performing periodic sync of pod CIDR routes
```
